### PR TITLE
Add Travis setup, including automated style checking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "foamStyleCheck"]
+	path = foamStyleCheck
+	url = https://github.com/petebachant/foamStyleCheck.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# Travis CI setup for OpenQBMM
+
+sudo: required
+dist: trusty
+language: cpp
+
+env:
+    # Test with both OpenFOAM 3.0 and 4
+    - OF_VERS=30
+    - OF_VERS=4
+
+before_install:
+    - sudo add-apt-repository http://dl.openfoam.org/ubuntu
+    - sudo sh -c "wget -O - http://dl.openfoam.org/gpg.key | apt-key add -"
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq openfoam${OF_VERS}
+    - sudo apt-get install -qq vera++
+
+install:
+    - source /opt/openfoam${OF_VERS}/etc/bashrc
+    - ./Allwmake
+
+before_script:
+    - source /opt/openfoam${OF_VERS}/etc/bashrc
+
+script:
+    # Should add an automated test runner script here
+    # - ./Alltest
+    - ./foamStyleCheck/checkStyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ dist: trusty
 language: cpp
 
 env:
-    # Test with both OpenFOAM 3.0 and 4
-    - OF_VERS=30
+    # Test with OpenFOAM 4 only
     - OF_VERS=4
 
 before_install:


### PR DESCRIPTION
Setup Travis CI to build against the latest OpenFOAM 4, then check the code style (incompletely). Would be great to have a script to automatically build and run all the test apps as well, so these are run for each push/PR. 