### PR TITLE
Removed solving of velocity moments change due to breakup and coalescence

### DIFF
--- a/applications/solvers/multiphase/interfacialModels/bubbleBreakupKernels/Alopaeus/Alopaeus.C
+++ b/applications/solvers/multiphase/interfacialModels/bubbleBreakupKernels/Alopaeus/Alopaeus.C
@@ -28,6 +28,7 @@ License
 #include "fundamentalConstants.H"
 #include "phaseModel.H"
 #include "PhaseCompressibleTurbulenceModel.H"
+#include "fvc.H"
 
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
@@ -88,11 +89,10 @@ Foam::bubbleBreakupKernels::Alopaeus::~Alopaeus()
 Foam::tmp<Foam::volScalarField>
 Foam::bubbleBreakupKernels::Alopaeus::Kb(const label nodei) const
 {
-    volScalarField epsilon
-    (
-        "epsilon",
-        fluid_.phase2().turbulence().epsilon()
-    );
+//     volScalarField epsilon("epsilon", fluid_.phase2().turbulence().epsilon());
+    const phaseModel& phase(fluid_.phase1());
+    volTensorField S(fvc::grad(phase.U()) + T(fvc::grad(phase.U())));
+    volScalarField epsilon(phase.nu()*(S && S));
     epsilon.max(SMALL);
 
     const volScalarField& d = fluid_.phase1().ds(nodei);

--- a/applications/solvers/multiphase/interfacialModels/coalescenceKernels/coalescenceEfficiencyKernels/CoulaloglouAndTavlarides/CoulaloglouAndTavlarides.C
+++ b/applications/solvers/multiphase/interfacialModels/coalescenceKernels/coalescenceEfficiencyKernels/CoulaloglouAndTavlarides/CoulaloglouAndTavlarides.C
@@ -26,6 +26,7 @@ License
 #include "CoulaloglouAndTavlarides.H"
 #include "addToRunTimeSelectionTable.H"
 #include "fundamentalConstants.H"
+#include "fvc.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -80,7 +81,10 @@ Foam::coalescenceEfficiencyKernels::CoulaloglouAndTavlarides::Pc
     const volScalarField& d1 = fluid_.phase1().ds(nodei);
     const volScalarField& d2 = fluid_.phase1().ds(nodej);
     const volScalarField& rho = fluid_.phase2().rho();
-    const volScalarField& epsilon = fluid_.phase2().turbulence().epsilon();
+//     const volScalarField& epsilon = fluid_.phase2().turbulence().epsilon();
+    const phaseModel& phase(fluid_.phase1());
+    volTensorField S(fvc::grad(phase.U()) + T(fvc::grad(phase.U())));
+    volScalarField epsilon(phase.nu()*(S && S));
     const dimensionedScalar& sigma = fluid_.sigma();
 
     return

--- a/applications/solvers/multiphase/interfacialModels/coalescenceKernels/coalescenceFrequencyKernels/CoulaloglouAndTavlarides/CoulaloglouAndTavlarides.C
+++ b/applications/solvers/multiphase/interfacialModels/coalescenceKernels/coalescenceFrequencyKernels/CoulaloglouAndTavlarides/CoulaloglouAndTavlarides.C
@@ -26,6 +26,7 @@ License
 #include "CoulaloglouAndTavlarides.H"
 #include "addToRunTimeSelectionTable.H"
 #include "fundamentalConstants.H"
+#include "fvc.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -75,7 +76,10 @@ Foam::coalescenceFrequencyKernels::CoulaloglouAndTavlarides::omega
     const label nodej
 ) const
 {
-    const volScalarField& epsilon = fluid_.phase2().turbulence().epsilon();
+//     const volScalarField& epsilon = fluid_.phase2().turbulence().epsilon();
+    const phaseModel& phase(fluid_.phase1());
+    volTensorField S(fvc::grad(phase.U()) + T(fvc::grad(phase.U())));
+    volScalarField epsilon(phase.nu()*(S && S));
 
     const volScalarField& d1 = fluid_.phase1().ds(nodei);
     const volScalarField& d2 = fluid_.phase1().ds(nodej);

--- a/applications/solvers/multiphase/interfacialModels/dragModels/segregated/segregated.C
+++ b/applications/solvers/multiphase/interfacialModels/dragModels/segregated/segregated.C
@@ -145,13 +145,8 @@ Foam::tmp<Foam::volScalarField> Foam::dragModels::segregated::K
     if (pair_.phase2().nNodes() > 1)
     {
         I *=
-            max
-            (
-                alpha2,
-                pair_.phase2().residualAlpha()
-                /pair_.phase2().nNodes()
-            )
-            /max
+            alpha2
+           /max
             (
                 pair_.phase2(),
                 pair_.phase2().residualAlpha()

--- a/applications/solvers/multiphase/twoPhaseSystem/phaseModels/pdPhaseModel/pdPhaseModel.H
+++ b/applications/solvers/multiphase/twoPhaseSystem/phaseModels/pdPhaseModel/pdPhaseModel.H
@@ -119,14 +119,8 @@ class pdPhaseModel
         //- Coalesence source
         tmp<volScalarField> coalescenceSource(const label momentOrder);
 
-        //- Coalesence source for velocity moments
-        tmp<volVectorField> coalescenceSourceU(const label momentOrder);
-
         //- Breakup source
         tmp<volScalarField> breakupSource(const label momentOrder);
-
-        //- Breakup source for velocity moments
-        tmp<volVectorField> breakupSourceU(const label momentOrder);
 
         //- Return daughterDistribution
         tmp<volScalarField> daughterDistribution

--- a/applications/solvers/multiphase/twoPhaseSystem/twoPhaseSystem.C
+++ b/applications/solvers/multiphase/twoPhaseSystem/twoPhaseSystem.C
@@ -914,11 +914,7 @@ void Foam::twoPhaseSystem::averageTransport()
 
             // Drag
           + Kd*phase2_->U()
-          - fvm::Sp
-            (
-                Kd,
-                phase1_->Us(nodei)
-            )
+          - fvm::Sp(Kd, phase1_->Us(nodei))
 
             // Virtual Mass
           + Vm(nodei)

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/T.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/T.air
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      T.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions          [0 0 0 1 0 0 0];
+
+internalField       uniform 300;
+
+boundaryField
+{
+    walls
+    {
+        type               zeroGradient;
+    }
+    outlet
+    {
+        type               inletOutlet;
+        phi                phi.air;
+        inletValue         $internalField;
+        value              $internalField;
+    }
+    inlet
+    {
+        type               fixedValue;
+        value              $internalField;
+    }
+    defaultFaces
+    {
+        type    empty;
+    }
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/T.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/T.water
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      T.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions          [0 0 0 1 0 0 0];
+
+internalField       uniform 350;
+
+boundaryField
+{
+    walls
+    {
+        type               zeroGradient;
+    }
+    outlet
+    {
+        type               inletOutlet;
+        phi                phi.water;
+        inletValue         $internalField;
+        value              $internalField;
+    }
+    inlet
+    {
+        type               fixedValue;
+        value              $internalField;
+    }
+    defaultFaces
+    {
+        type    empty;
+    }
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/Theta
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/Theta
@@ -1,0 +1,47 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      Theta;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions          [0 2 -2 0 0 0 0];
+
+internalField   uniform 0.0;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           uniform 1.0e-5;
+    }
+
+    outlet
+    {
+        type            inletOutlet;
+        inletValue      uniform 1.0e-5;
+        value           uniform 1.0e-5;
+    }
+
+    walls
+    {
+        type            zeroGradient;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/U.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/U.air
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    object      U.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 1 -1 0 0 0 0];
+
+internalField   uniform (0 0 0);
+
+boundaryField
+{
+    inlet
+    {
+        type                fixedValue;
+        value               uniform (0 10 0);
+    }
+    outlet
+    {
+        type                pressureInletOutletVelocity;
+        phi                 phi.air;
+        value               $internalField;
+    }
+    walls
+    {
+        type                fixedValue;
+        value               uniform (0 0 0);
+    }
+    defaultFaces
+    {
+        type                empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/U.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/U.water
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    object      U.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 1 -1 0 0 0 0];
+
+internalField   uniform (0 0 0);
+
+boundaryField
+{
+    inlet
+    {
+        type                fixedValue;
+        value               uniform (0 0 0);
+    }
+    outlet
+    {
+        type                pressureInletOutletVelocity;
+        phi                 phi.water;
+        value               $internalField;
+    }
+    walls
+    {
+        type                fixedValue;
+        value               uniform (0 0 0);
+    }
+    defaultFaces
+    {
+        type                empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/alpha.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/alpha.air
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    location    "0";
+    object      alpha.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 0 0 0 0 0 0];
+
+internalField   uniform 1.0;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           uniform 1;
+    }
+    outlet
+    {
+        type            inletOutlet;
+        phi             phi.air;
+        inletValue      uniform 1;
+    }
+    walls
+    {
+        type            zeroGradient;
+    }
+    defaultFaces
+    {
+        type    empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/alphat.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/alphat.air
@@ -1,0 +1,48 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      alphat.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [1 -1 -1 0 0 0 0];
+
+internalField   uniform 0;
+
+boundaryField
+{
+    inlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            compressible::alphatWallFunction;
+        Prt             0.85;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/alphat.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/alphat.water
@@ -1,0 +1,48 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      alphat.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [1 -1 -1 0 0 0 0];
+
+internalField   uniform 0;
+
+boundaryField
+{
+    inlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            compressible::alphatWallFunction;
+        Prt             0.85;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/epsilon.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/epsilon.air
@@ -1,0 +1,49 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      epsilon.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -3 0 0 0 0];
+
+internalField   uniform 1.5e-4;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            inletOutlet;
+        phi             phi.air;
+        inletValue      $internalField;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            epsilonWallFunction;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/epsilon.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/epsilon.water
@@ -1,0 +1,49 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      epsilon.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -3 0 0 0 0];
+
+internalField   uniform 1.5e-4;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            inletOutlet;
+        phi             phi.water;
+        inletValue      $internalField;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            epsilonWallFunction;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/epsilonm
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/epsilonm
@@ -1,0 +1,49 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      epsilonm;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -3 0 0 0 0];
+
+internalField   uniform 1.5e-4;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            inletOutlet;
+        phi             phim;
+        inletValue      $internalField;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            zeroGradient;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/k.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/k.air
@@ -1,0 +1,49 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      k.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -2 0 0 0 0];
+
+internalField   uniform 3.75e-5;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            inletOutlet;
+        phi             phi.air;
+        inletValue      $internalField;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            kqRWallFunction;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/k.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/k.water
@@ -1,0 +1,49 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      k.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -2 0 0 0 0];
+
+internalField   uniform 3.75e-5;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            inletOutlet;
+        phi             phi.water;
+        inletValue      $internalField;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            kqRWallFunction;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/km
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/km
@@ -1,0 +1,49 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      km;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -2 0 0 0 0];
+
+internalField   uniform 3.75e-5;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            inletOutlet;
+        phi             phim;
+        inletValue      $internalField;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            zeroGradient;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/nut.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/nut.air
@@ -1,0 +1,47 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      nut.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -1 0 0 0 0];
+
+internalField   uniform 1e-8;
+
+boundaryField
+{
+    inlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            nutkWallFunction;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/nut.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/nut.water
@@ -1,0 +1,47 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      nut.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 2 -1 0 0 0 0];
+
+internalField   uniform 1e-8;
+
+boundaryField
+{
+    inlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    outlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+
+    walls
+    {
+        type            nutkWallFunction;
+        value           $internalField;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/p
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/p
@@ -1,0 +1,44 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      p;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions          [1 -1 -2 0 0 0 0];
+
+internalField       uniform 1e5;
+
+boundaryField
+{
+    inlet
+    {
+        type                calculated;
+        value               $internalField;
+    }
+    outlet
+    {
+        type                calculated;
+        value               $internalField;
+    }
+    walls
+    {
+        type                calculated;
+        value               $internalField;
+    }
+    defaultFaces
+    {
+        type                empty;
+    }
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/validation/polydisperseBubbleFoam/angledMixer/0.org/p_rgh
+++ b/validation/polydisperseBubbleFoam/angledMixer/0.org/p_rgh
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      p_rgh;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions          [1 -1 -2 0 0 0 0];
+
+internalField       uniform 1e5;
+
+boundaryField
+{
+    inlet
+    {
+        type            fixedFluxPressure;
+        value           $internalField;
+    }
+    outlet
+    {
+        type            prghPressure;
+        p               $internalField;
+        value           $internalField;
+    }
+    walls
+    {
+        type            fixedFluxPressure;
+        value           $internalField;
+    }
+    defaultFaces
+    {
+        type    empty;
+    }
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/g
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/g
@@ -1,0 +1,22 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       uniformDimensionedVectorField;
+    location    "constant";
+    object      g;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 1 -2 0 0 0 0];
+value           (0 -9.81 0);
+
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/phaseProperties
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/phaseProperties
@@ -1,0 +1,135 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      phaseProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+phases (air water);
+
+air
+{
+    type            polydispersePhaseModel;
+    residualAlpha   1e-6;
+    minD            1e-4;
+    maxD            5e-2;
+}
+
+water
+{
+    type            monodispersePhaseModel;
+    residualAlpha   1e-6;
+    d               1e-4;
+}
+
+pMin    1e3;
+pMax    1e7;
+
+blending
+{
+    default
+    {
+        type                            linear;
+        maxFullyDispersedAlpha.air      0.3;
+        maxPartlyDispersedAlpha.air     0.5;
+        maxFullyDispersedAlpha.water    0.3;
+        maxPartlyDispersedAlpha.water   0.5;
+    }
+}
+
+sigma
+(
+    (air and water)   0.07
+);
+
+aspectRatio
+(
+    (air in water)
+    {
+        type            constant;
+        E0              1.0;
+    }
+
+    (water in air)
+    {
+        type            constant;
+        E0              1.0;
+    }
+);
+
+drag
+(
+    (air in water)
+    {
+        type            Tomiyama;
+        residualRe      1e-3;
+        swarmCorrection
+        {
+            type        none;
+        }
+    }
+
+    (water in air)
+    {
+        type            SchillerNaumann;
+        residualRe      1e-3;
+        swarmCorrection
+        {
+            type        none;
+        }
+    }
+
+    (air and water)
+    {
+        type            segregated;
+        residualRe      1e-3;
+        residualAlpha   1e-4;
+        m               0.5;
+        n               8;
+        swarmCorrection
+        {
+            type        none;
+        }
+    }
+);
+
+
+turbulentDispersion
+(
+);
+
+virtualMass
+(
+    (air in water)
+    {
+        type            constantCoefficient;
+        Cvm             0.5;
+    }
+    (water in air)
+    {
+        type            constantCoefficient;
+        Cvm             0.5;
+    }
+);
+
+lift
+(
+);
+
+wallLubrication
+(
+);
+
+bubblePressure
+(
+);

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/phaseProperties
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/phaseProperties
@@ -20,7 +20,7 @@ phases (air water);
 air
 {
     type            polydispersePhaseModel;
-    residualAlpha   1e-6;
+    residualAlpha   1e-4;
     minD            1e-4;
     maxD            5e-2;
 }
@@ -28,7 +28,7 @@ air
 water
 {
     type            monodispersePhaseModel;
-    residualAlpha   1e-6;
+    residualAlpha   1e-4;
     d               1e-4;
 }
 

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/populationBalanceProperties
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/populationBalanceProperties
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      populationaBalanceProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+coalescence off;
+
+coalescenceKernel
+{
+    coalescenceFrequencyKernel PrinceAndBlanch;
+    coalescenceEfficiencyKernel CoulaloglouAndTavlarides;
+
+    Ca      Ca      [ 0 0 0 0 0 0 0 ]  0.88;
+    Ceff    Ceff    [ 0 0 0 0 0 0 0 ]  6.0e9;
+    ReExp   ReExp   [ 0 0 0 0 0 0 0 ]  -0.732;
+    WeExp   WeExp   [ 0 0 0 0 0 0 0 ]  0.317;
+}
+
+breakup off;
+
+breakupKernel
+{
+    breakupKernel Alopaeus;
+    Cb        Cb        [ 0 0 -1 0 0 0 0 ] 6.0;
+}
+
+daughterDistribution
+{
+    daughterDistribution uniform;
+}
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/populationBalanceProperties
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/populationBalanceProperties
@@ -15,12 +15,13 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
+ode on;
 
-coalescence off;
+coalescence on;
 
 coalescenceKernel
 {
-    coalescenceFrequencyKernel PrinceAndBlanch;
+    coalescenceFrequencyKernel CoulaloglouAndTavlarides;
     coalescenceEfficiencyKernel CoulaloglouAndTavlarides;
 
     Ca      Ca      [ 0 0 0 0 0 0 0 ]  0.88;
@@ -29,7 +30,7 @@ coalescenceKernel
     WeExp   WeExp   [ 0 0 0 0 0 0 0 ]  0.317;
 }
 
-breakup off;
+breakup on;
 
 breakupKernel
 {

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/quadratureProperties.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/quadratureProperties.air
@@ -1,0 +1,50 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      quadratureProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+fieldMomentInversion    basicFieldMomentInversion;
+
+basicMomentInversion
+{
+    univariateMomentInversion   Gauss;
+}
+
+moments
+(
+    (0)
+    (1)
+    (2)
+    (3)
+    (4)
+    (5)
+);
+
+nodes
+(
+    node0
+    {}
+    node1
+    {}
+    node2
+    {}
+);
+
+residuals
+{
+    minM0   1;
+    minM1   1e-6;
+}
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/thermophysicalProperties.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/thermophysicalProperties.air
@@ -1,0 +1,48 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      thermophysicalProperties.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+thermoType
+{
+    type            heRhoThermo;
+    mixture         pureMixture;
+    transport       const;
+    thermo          hConst;
+    equationOfState perfectGas;
+    specie          specie;
+    energy          sensibleInternalEnergy;
+}
+
+mixture
+{
+    specie
+    {
+        molWeight   28.9;
+    }
+    thermodynamics
+    {
+        Cp          1007;
+        Hf          0;
+    }
+    transport
+    {
+        mu          1.84e-05;
+        Pr          0.7;
+    }
+}
+
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/thermophysicalProperties.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/thermophysicalProperties.water
@@ -1,0 +1,53 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      thermophysicalProperties.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+thermoType
+{
+    type            heRhoThermo;
+    mixture         pureMixture;
+    transport       const;
+    thermo          hConst;
+    equationOfState perfectFluid;
+    specie          specie;
+    energy          sensibleInternalEnergy;
+}
+
+mixture
+{
+    specie
+    {
+        molWeight   18;
+    }
+    equationOfState
+    {
+        R           3000;
+        rho0        1027;
+    }
+    thermodynamics
+    {
+        Cp          4195;
+        Hf          0;
+    }
+    transport
+    {
+        mu          3.645e-4;
+        Pr          2.289;
+    }
+}
+
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/turbulenceProperties.air
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/turbulenceProperties.air
@@ -1,0 +1,46 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      turbulenceProperties.air;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+simulationType  LES;
+
+RAS
+{
+    RASModel mixtureKEpsilon;
+
+    turbulence      on;
+    printCoeffs     on;
+
+    mixtureKEpsilonCoeffs
+    {
+        Cp  0;
+        C3  0;
+    }
+}
+LES
+{
+    LESModel continuousGasKEqn;
+
+    turbulence      on;
+    printCoeffs     on;
+
+    delta           cubeRootVol;
+
+    cubeRootVolCoeffs
+    {
+    }
+}
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/constant/turbulenceProperties.water
+++ b/validation/polydisperseBubbleFoam/angledMixer/constant/turbulenceProperties.water
@@ -1,0 +1,46 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      turbulenceProperties.water;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+simulationType  LES;
+
+RAS
+{
+    RASModel mixtureKEpsilon;
+
+    turbulence      on;
+    printCoeffs     on;
+
+    mixtureKEpsilonCoeffs
+    {
+        Cp  0;
+        C3  0;
+    }
+}
+LES
+{
+    LESModel NicenoKEqn;
+
+    turbulence      on;
+    printCoeffs     on;
+
+    delta           cubeRootVol;
+
+    cubeRootVolCoeffs
+    {
+    }
+}
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/system/blockMeshDict
+++ b/validation/polydisperseBubbleFoam/angledMixer/system/blockMeshDict
@@ -1,0 +1,98 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      blockMeshDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+convertToMeters .001;
+
+pipeR       5;
+pipenR      -5;
+topR        500;
+topnR       -500;
+
+y1      2000;
+y2      6000;
+
+depth   5;
+
+nAngleHPts  100;
+nTopPts     100;
+nHorPts     50;
+
+nDepthPts   1;
+
+vertices
+(
+    ($pipeR 0 0)
+    ($topR $y1 0)
+    ($topR $y2 0)
+    ($topnR $y2 0)
+    ($topnR $y1 0)
+    ($pipenR 0 0)
+
+    ($pipeR 0 $depth)
+    ($topR $y1 $depth)
+    ($topR $y2 $depth)
+    ($topnR $y2 $depth)
+    ($topnR $y1 $depth)
+    ($pipenR 0 $depth)
+
+);
+
+blocks
+(
+    hex (5 0 1 4 11 6 7 10) ($nHorPts $nAngleHPts $nDepthPts) simpleGrading (1 1 1)
+    hex (4 1 2 3 10 7 8 9) ($nHorPts $nTopPts $nDepthPts) simpleGrading (1 1 1)
+);
+
+edges
+(
+);
+
+boundary
+(
+    inlet
+    {
+        type            patch;
+        faces
+        (
+            (0 5 11 6)
+        );
+    }
+    outlet
+    {
+        type            patch;
+        faces
+        (
+            (2 3 9 8)
+        );
+    }
+    walls
+    {
+        type            wall;
+        faces
+        (
+            (0 1 7 6)
+            (1 8 2 7)
+            (3 9 10 4)
+            (4 5 11 10)
+        );
+    }
+);
+
+mergePatchPairs
+(
+);
+
+// ************************************************************************* //)))))

--- a/validation/polydisperseBubbleFoam/angledMixer/system/controlDict
+++ b/validation/polydisperseBubbleFoam/angledMixer/system/controlDict
@@ -19,19 +19,19 @@ application     polydisperseBubbleFoam;
 
 startFrom       latestTime;
 
-startTime       0;
+startTime       1.0;
 
 stopAt          endTime;
 
 endTime         250;
 
-deltaT          1e-3;
+deltaT          1e-5;
 
 writeControl    adjustableRunTime;
 
 writeInterval   1;
 
-purgeWrite      100;
+purgeWrite      250;
 
 writeFormat     ascii;
 
@@ -47,7 +47,7 @@ runTimeModifiable yes;
 
 adjustTimeStep  yes;
 
-maxCo           0.05;
+maxCo           0.5;
 
 maxDeltaT       1;
 
@@ -57,7 +57,7 @@ functions
     {
         type            fieldAverage;
         functionObjectLibs ( "libfieldFunctionObjects.so" );
-        writeControl    writeTime;
+        outputControl   outputTime;
         timeStart       50;
         fields
         (
@@ -82,7 +82,7 @@ functions
                  base        time;
             }
 
-            p_rgh
+            p
             {
                  mean        on;
                  prime2Mean  off;
@@ -94,22 +94,6 @@ functions
                  prime2Mean  off;
                  base        time;
             }
-        );
-    }
-    pProbes
-    {
-        type        probes;
-        functionObjectLibs ("libsampling.so");
-        probeLocations
-        (
-            (0  0.038   0)
-            (0  0.213   0)
-            (0  0.413   0)
-        );
-
-        fields
-        (
-            p_rgh
         );
     }
 }

--- a/validation/polydisperseBubbleFoam/angledMixer/system/decomposeParDict
+++ b/validation/polydisperseBubbleFoam/angledMixer/system/decomposeParDict
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      decomposeParDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+numberOfSubdomains 15;
+
+method          scotch;
+
+simpleCoeffs
+{
+    n               (1 12 1);
+    delta           0.001;
+}
+
+hierarchicalCoeffs
+{
+    n               (1 1 1);
+    delta           0.001;
+    order           xyz;
+}
+
+manualCoeffs
+{
+    dataFile        "";
+}
+
+distributed     no;
+
+roots           ( );
+
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/system/fvSchemes
+++ b/validation/polydisperseBubbleFoam/angledMixer/system/fvSchemes
@@ -1,0 +1,83 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSchemes;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+ddtSchemes
+{
+    default         Euler;
+}
+
+gradSchemes
+{
+    default         cellLimited     leastSquares .2;
+    grad(p_rgh)     leastSquares;
+}
+
+divSchemes
+{
+    default                         Gauss upwind phi;
+
+    div(phi,alpha.air)              Gauss upwind;
+    div(phir,alpha.air)             Gauss upwind;
+    div(phi,alpha.water)            Gauss upwind;
+    "div\(phir,alpha.*,alpha.*\)"   Gauss upwind;
+
+    "div\(alphaRhoPhi.*,U.*\)"      Gauss upwind;
+    "div\(phi.*,U.*\)"              Gauss upwind;
+    "div\(phi.air,moment.*\)"       Gauss upwind;
+
+    "div\(alphaRhoPhi.*,(h|e).*\)"  Gauss upwind;
+    "div\(alphaRhoPhi.*,K.*\)"      Gauss upwind;
+    "div\(alphaPhi.*,p\)"           Gauss upwind;
+
+    "div\(alphaRhoPhi.*,(k|epsilon).*\)"  Gauss upwind;
+    "div\(phim,(k|epsilon)m\)"      Gauss upwind;
+
+    "div\(\(\(\(alpha.*\*thermo:rho.*\)\*nuEff.*\)\*dev2\(T\(grad\(U.*\)\)\)\)\)" Gauss linear;
+
+    div((((alpha.air*rho.air)*nu.air)*dev2(T(grad(U.air))))) Gauss linear;
+}
+
+laplacianSchemes
+{
+    default         Gauss linear corrected;
+}
+
+interpolationSchemes
+{
+    default         linear;
+
+    "interpolate\(moment.*\)" upwind phi.air;
+
+    reconstruct(U)          upwind;
+    reconstruct(Us)         upwind;
+    reconstruct(weight)     upwind;
+    reconstruct(abscissa)   upwind;
+    reconstruct(sigma)      upwind;
+}
+
+snGradSchemes
+{
+    default         corrected;
+}
+
+wallDist
+{
+    method meshWave;
+}
+
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/system/fvSolution
+++ b/validation/polydisperseBubbleFoam/angledMixer/system/fvSolution
@@ -1,0 +1,129 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solvers
+{
+    "alpha.*"
+    {
+        solver          GAMG;
+        preconditioner  DIC;
+        nAlphaCorr      2;
+        nAlphaSubCycles 1;
+    }
+    p_rgh
+    {
+        solver          GAMG;
+        smoother        DIC;
+        preconditioner  DIC;
+        nPreSweeps      0;
+        nPostSweeps     2;
+        nFinestSweeps   2;
+        cacheAgglomeration true;
+        nCellsInCoarsestLevel 10;
+        agglomerator    faceAreaPair;
+        mergeLevels     2;
+        tolerance       1e-10;
+        maxIter         1000;
+    }
+
+    p_rghFinal
+    {
+        $p_rgh;
+        relTol          0;
+    }
+
+    "U.air.*"
+    {
+        solver          PBiCG;
+        preconditioner  DILU;
+        tolerance       1e-8;
+        relTol          0;
+        minIter         1;
+    }
+
+    U.water
+    {
+        solver          smoothSolver;
+        preconditioner  symGaussSeidel;
+        tolerance       1e-8;
+        relTol          0;
+        minIter         1;
+    }
+
+    "Up.*"
+    {
+        solver          diagonal;
+        smoother        DIC;
+        tolerance       1e-12;
+        relTol          0;
+        minIter         1;
+    }
+
+    "moment.*"
+    {
+        solver          PBiCG;
+        preconditioner  DILU;
+        tolerance       1e-12;
+        relTol          0;
+        minIter         1;
+    }
+
+    "e.*"
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-7;
+        relTol          0;
+        minIter         1;
+    }
+
+    "(k|epsilon|Theta).*"
+    {
+        solver          PBiCG;
+        preconditioner  DILU;
+        tolerance       1e-7;
+        relTol          0;
+    }
+}
+
+PIMPLE
+{
+    nOuterCorrectors 5;
+    nCorrectors      2;
+    nNonOrthogonalCorrectors 0;
+    pRefCell 0;
+    pRefValue 1e5;
+    residualControl
+    {
+        p_rgh
+        {
+            tolerance 1e-6;
+            relTol    0;
+        }
+    }
+}
+
+relaxationFactors
+{
+    equations
+    {
+        p_rgh       1;
+    }
+}
+
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/system/momentGenerationDict
+++ b/validation/polydisperseBubbleFoam/angledMixer/system/momentGenerationDict
@@ -1,0 +1,97 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      momentGenerationDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+phases
+(
+    air
+);
+
+boundaries
+{
+    inlet
+    {
+        type    fixedValue;
+        value   uniform 0;
+    }
+    defaultFaces
+    {
+        type    empty;
+    }
+    walls
+    {
+        type    zeroGradient;
+    }
+    outlet
+    {
+        type    zeroGradient;
+    }
+}
+
+air
+{
+    type                alphaAndDiameter;
+    Radau               false;
+    weightDimension     [0 -3 0 0 0 0 0];
+    abscissaDimension   [1 0 0 0 0 0 0];
+
+    internal
+    {
+
+        node0
+        {
+            rho rho [1 -3 0 0 0 0 0] 1.40;
+            dia dia [0 1 0 0 0 0 0] 1.0e-3;
+            alpha alpha [0 0 0 0 0 0 0] 0.33;
+        }
+        node1
+        {
+            rho rho [1 -3 0 0 0 0 0] 1.40;
+            dia dia [0 1 0 0 0 0 0] 2.5e-3;
+            alpha alpha [0 0 0 0 0 0 0] 0.34;
+        }
+        node2
+        {
+            rho rho [1 -3 0 0 0 0 0] 1.40;
+            dia dia [0 1 0 0 0 0 0] 4.0e-3;
+            alpha alpha [0 0 0 0 0 0 0] 0.33;
+        }
+    }
+    inlet
+    {
+        node0
+        {
+            rho rho [1 -3 0 0 0 0 0] 1.40;
+            dia dia [0 1 0 0 0 0 0] 1.0e-3;
+            alpha alpha [0 0 0 0 0 0 0] 0.33;
+        }
+        node1
+        {
+            rho rho [1 -3 0 0 0 0 0] 1.40;
+            dia dia [0 1 0 0 0 0 0] 2.5e-3;
+            alpha alpha [0 0 0 0 0 0 0] 0.34;
+        }
+        node2
+        {
+            rho rho [1 -3 0 0 0 0 0] 1.40;
+            dia dia [0 1 0 0 0 0 0] 4.0e-3;
+            alpha alpha [0 0 0 0 0 0 0] 0.33;
+        }
+    }
+}
+
+
+// ************************************************************************* //

--- a/validation/polydisperseBubbleFoam/angledMixer/system/setFieldsDict
+++ b/validation/polydisperseBubbleFoam/angledMixer/system/setFieldsDict
@@ -1,0 +1,37 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  dev                                   |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      setFieldsDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+regions
+(
+    boxToCell
+    {
+        box (-2 0 0) (2 2.5 0.1);
+        fieldValues
+        (
+            volScalarFieldValue alpha.air       0
+            volScalarFieldValue moment.0.air    0
+            volScalarFieldValue moment.1.air    0
+            volScalarFieldValue moment.2.air    0
+            volScalarFieldValue moment.3.air    0
+            volScalarFieldValue moment.4.air    0
+            volScalarFieldValue moment.5.air    0
+        );
+    }
+);
+
+
+// ************************************************************************* //


### PR DESCRIPTION
Since only size abscissae change due to break up and coalescence, the size moments are integrated with respect to the source terms, the weights and abscissae are updated, then the velocity moments are reconstructed using the new quadrature. This eliminated the need to compute the coalescence and breakup kernels twice (very expensive).