### PR TITLE
BUG: Fixed reading of min and max abscissa

### DIFF
--- a/src/quadratureMethods/fieldMomentInversion/basicFieldMomentInversion/basicFieldMomentInversion.C
+++ b/src/quadratureMethods/fieldMomentInversion/basicFieldMomentInversion/basicFieldMomentInversion.C
@@ -50,8 +50,8 @@ Foam::basicFieldMomentInversion::basicFieldMomentInversion
 )
 :
     fieldMomentInversion(dict, nMoments, nSecondaryNodes),
-    minKnownAbscissa_(dict.lookupOrDefault("minKnownAbscissa", 0)),
-    maxKnownAbscissa_(dict.lookupOrDefault("maxKnownAbscissa", 1)),
+    minKnownAbscissa_(dict.lookupOrDefault("minKnownAbscissa", 0.0)),
+    maxKnownAbscissa_(dict.lookupOrDefault("maxKnownAbscissa", 1.0)),
     nFixedQuadraturePoints_(0),
     momentInverter_
     (


### PR DESCRIPTION
Changed type from label to scalar in reading of min and max abscissa in basicFieldMomentInversion