### PR TITLE
BUG: Changed name of volumeAveraged function objects

### DIFF
--- a/validation/pbeTransportFoam/serraTaylorCouette/75rpm/system/controlDict.flow
+++ b/validation/pbeTransportFoam/serraTaylorCouette/75rpm/system/controlDict.flow
@@ -50,7 +50,7 @@ functions
     {
         libs ("libutilityFunctionObjects.so");
         type coded;
-        name volumeAverage;
+        name epsilonVolumeAverage;
         writeControl timeStep;
 
         codeExecute

--- a/validation/pbeTransportFoam/serraTaylorCouette/75rpm/system/controlDict.populationBalance
+++ b/validation/pbeTransportFoam/serraTaylorCouette/75rpm/system/controlDict.populationBalance
@@ -56,7 +56,7 @@ functions
     {
         libs ("libutilityFunctionObjects.so");
         type coded;
-        name volumeAverage;
+        name d43volumeAverage;
         writeControl timeStep;
 
         codeExecute


### PR DESCRIPTION
Changed so that the function objects to compute volume averages of epsilon and d43 in controlDict.flow and controlDict.populationBalance both compile