### PR TITLE
COMP: resolve some general linkage issues (mingw)

### DIFF
--- a/applications/solvers/compressible/explicitRhoFoam/compressibleSystem/Make/options
+++ b/applications/solvers/compressible/explicitRhoFoam/compressibleSystem/Make/options
@@ -6,18 +6,19 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
 endif
 
 EXE_INC = \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
     -I$(LIB_SRC)/transportModels/incompressible/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/phaseCompressible/lnInclude \
-    -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/sampling/lnInclude \
     -I../../ButcherTable/lnInclude
 
 LIB_LIBS = \
+    -lfiniteVolume \
+    -lmeshTools \
     -lincompressibleTransportModels \
     -lcompressibleTransportModels \
     -lfluidThermophysicalModels \

--- a/applications/utilities/phaseMeanVelocityForce/Make/options
+++ b/applications/utilities/phaseMeanVelocityForce/Make/options
@@ -10,5 +10,7 @@ EXE_INC = \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/fvOptions/lnInclude
 
-LIB_LIBs = \
+LIB_LIBS = \
+    -lfiniteVolume \
+    -lmeshTools \
     -lfvOptions

--- a/applications/utilities/phaseMeanVelocityForce/phaseCompressibleMeanVelocityForce/phaseCompressibleMeanVelocityForce.C
+++ b/applications/utilities/phaseMeanVelocityForce/phaseCompressibleMeanVelocityForce/phaseCompressibleMeanVelocityForce.C
@@ -225,7 +225,7 @@ void Foam::fv::phaseCompressibleMeanVelocityForce::constrain
     const label
 )
 {
-    if (rAPtr_.empty())
+    if (!rAPtr_.valid())
     {
         rAPtr_.reset
         (

--- a/applications/utilities/phaseMeanVelocityForce/phaseIncompressibleMeanVelocityForce/phaseIncompressibleMeanVelocityForce.C
+++ b/applications/utilities/phaseMeanVelocityForce/phaseIncompressibleMeanVelocityForce/phaseIncompressibleMeanVelocityForce.C
@@ -217,7 +217,7 @@ void Foam::fv::phaseIncompressibleMeanVelocityForce::constrain
     const label
 )
 {
-    if (rAPtr_.empty())
+    if (!rAPtr_.valid())
     {
         rAPtr_.reset
         (

--- a/src/quadratureMethods/quadratureNode/Make/options
+++ b/src/quadratureMethods/quadratureNode/Make/options
@@ -12,4 +12,5 @@ EXE_INC = \
     -I../momentSets/lnInclude \
     -I../moments \
 
-LIB_LIBS =
+LIB_LIBS = \
+    -lfiniteVolume


### PR DESCRIPTION
Some minor changes for resolving missed libraries. Might also be needed for the AOCC linker.

Does _not_ yet address the cyclic depends of phaseModel, phaseSystem etc.  For that I think that it is reasonable to follow a similar approach that we recently did with [merge 379](https://develop.openfoam.com/Development/openfoam/-/merge_requests/379).  Might also help when refactoring for .org and .com versions.
