### PR TITLE
COMP: prefer autoPtr::reset() to autoPtr::set()

### DIFF
--- a/applications/solvers/compressible/explicitRhoFoam/compressibleSystem/compressibleSystem.C
+++ b/applications/solvers/compressible/explicitRhoFoam/compressibleSystem/compressibleSystem.C
@@ -231,11 +231,11 @@ Foam::compressibleSystem::compressibleSystem(const fvMesh& mesh)
             )
         );
     }
-    
+
     thermoPtr_->validate("compressibleSystem ", "e");
     calcConservativeVariables();
 
-    integrator_.set(new fluxIntegrator(*this));
+    integrator_.reset(new fluxIntegrator(*this));
     fluxFunction_ = fluxFunction::New(mesh_);
 }
 

--- a/applications/solvers/multiphase/twoPhaseSystem/BlendedInterfacialModel/BlendedInterfacialModel.C
+++ b/applications/solvers/multiphase/twoPhaseSystem/BlendedInterfacialModel/BlendedInterfacialModel.C
@@ -79,7 +79,7 @@ Foam::BlendedInterfacialModel<modelType>::BlendedInterfacialModel
 {
     if (modelTable.found(pair_))
     {
-        model_.set
+        model_.reset
         (
             modelType::New
             (
@@ -91,7 +91,7 @@ Foam::BlendedInterfacialModel<modelType>::BlendedInterfacialModel
 
     if (modelTable.found(pair1In2_))
     {
-        model1In2_.set
+        model1In2_.reset
         (
             modelType::New
             (
@@ -103,7 +103,7 @@ Foam::BlendedInterfacialModel<modelType>::BlendedInterfacialModel
 
     if (modelTable.found(pair2In1_))
     {
-        model2In1_.set
+        model2In1_.reset
         (
             modelType::New
             (

--- a/applications/solvers/multiphase/twoPhaseSystem/phaseModels/polydispersePhaseModel/polydispersePhaseModel.C
+++ b/applications/solvers/multiphase/twoPhaseSystem/phaseModels/polydispersePhaseModel/polydispersePhaseModel.C
@@ -751,7 +751,7 @@ Foam::polydispersePhaseModel::polydispersePhaseModel
 
 void Foam::polydispersePhaseModel::setModels()
 {
-    coalescenceKernel_.set
+    coalescenceKernel_.reset
     (
         new populationBalanceSubModels::aggregationKernels::coalescence
         (

--- a/applications/solvers/multiphase/twoPhaseSystem/phasePair/orderedPhasePair/orderedPhasePair.C
+++ b/applications/solvers/multiphase/twoPhaseSystem/phasePair/orderedPhasePair/orderedPhasePair.C
@@ -43,7 +43,7 @@ Foam::orderedPhasePair::orderedPhasePair
 {
     if (aspectRatioTable.found(*this))
     {
-        aspectRatio_.set
+        aspectRatio_.reset
         (
             aspectRatioModel::New
             (

--- a/applications/solvers/multiphase/twoPhaseSystem/twoPhaseSystem.C
+++ b/applications/solvers/multiphase/twoPhaseSystem/twoPhaseSystem.C
@@ -148,7 +148,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
     phasePair::scalarTable sigmaTable(lookup("sigma"));
     phasePair::dictTable aspectRatioTable(lookup("aspectRatio"));
 
-    pair_.set
+    pair_.reset
     (
         new phasePair
         (
@@ -159,7 +159,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
         )
     );
 
-    pair1In2_.set
+    pair1In2_.reset
     (
         new orderedPhasePair
         (
@@ -171,7 +171,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
         )
     );
 
-    pair2In1_.set
+    pair2In1_.reset
     (
         new orderedPhasePair
         (
@@ -186,7 +186,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
 
     // Models
 
-    drag_.set
+    drag_.reset
     (
         new BlendedInterfacialModel<dragModel>
         (
@@ -203,7 +203,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
         )
     );
 
-    virtualMass_.set
+    virtualMass_.reset
     (
         new BlendedInterfacialModel<virtualMassModel>
         (
@@ -219,7 +219,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
         )
     );
 
-    lift_.set
+    lift_.reset
     (
         new BlendedInterfacialModel<liftModel>
         (
@@ -235,7 +235,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
         )
     );
 
-    wallLubrication_.set
+    wallLubrication_.reset
     (
         new BlendedInterfacialModel<wallLubricationModel>
         (
@@ -251,7 +251,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
         )
     );
 
-    turbulentDispersion_.set
+    turbulentDispersion_.reset
     (
         new BlendedInterfacialModel<turbulentDispersionModel>
         (
@@ -267,7 +267,7 @@ Foam::twoPhaseSystem::twoPhaseSystem
         )
     );
 
-    bubblePressure_.set
+    bubblePressure_.reset
     (
         new BlendedInterfacialModel<bubblePressureModel>
         (

--- a/applications/solvers/velocityDistributionTransport/phaseModel/phasePair/orderedPhasePair/orderedPhasePair.C
+++ b/applications/solvers/velocityDistributionTransport/phaseModel/phasePair/orderedPhasePair/orderedPhasePair.C
@@ -41,7 +41,7 @@ Foam::orderedPhasePair::orderedPhasePair
 :
     phasePair(dispersed, continuous, g, sigma, true)
 {
-    aspectRatio_.set
+    aspectRatio_.reset
     (
         aspectRatioModel::New
         (

--- a/src/quadratureMethods/momentAdvection/univariate/firstOrderKineticUnivariateAdvection/firstOrderKineticUnivariateAdvection.C
+++ b/src/quadratureMethods/momentAdvection/univariate/firstOrderKineticUnivariateAdvection/firstOrderKineticUnivariateAdvection.C
@@ -183,7 +183,7 @@ Foam::univariateAdvection::firstOrderKinetic::firstOrderKinetic
         );
     }
 
-    momentFieldInverter_.set
+    momentFieldInverter_.reset
     (
         new basicFieldMomentInversion
         (


### PR DESCRIPTION
- both work identically except that set() had an additional
  runtime check that autoPtr was not previously used.

  Although the check still exists in the .org version
  (was removed Feb-2018 from the openfoam.com version),
  it was never actually used in the OpenFOAM source tree
  except, oddly enough, within constructors where the autoPtr
  more certainly was not set anyhow.

  Now treat the set() method as cruft and prefer the reset() method
  for more similarity with std::unique_ptr and the reset() method
  is 'noexcept' as well.