### PR TITLE
COMP: adjust Make/options for thermoTools lib (OpenFOAM-v2206)

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -9,6 +9,12 @@ targetType=libso
 
 moduleName="OpenQBMM"
 
+if [ "$FOAM_MODULE_PREFIX" = false ]
+then
+    echo "Compilation of $moduleName is disabled (prefix=false)"
+    exit 0
+fi
+
 echo "========================================"
 date "+%Y-%m-%d %H:%M:%S %z" 2>/dev/null || echo "date is unknown"
 echo "Starting compile of $moduleName with ${WM_PROJECT_DIR##*/}"

--- a/applications/solvers/compressible/explicitRhoFoam/Make/options
+++ b/applications/solvers/compressible/explicitRhoFoam/Make/options
@@ -8,6 +8,12 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
@@ -27,6 +33,7 @@ EXE_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lfiniteVolume \
     -ldynamicFvMesh \
     -lmeshTools \

--- a/applications/solvers/compressible/explicitRhoFoam/compressiblePbeTransportFoam/Make/options
+++ b/applications/solvers/compressible/explicitRhoFoam/compressiblePbeTransportFoam/Make/options
@@ -10,6 +10,12 @@ endif
 
 QBMM_SRC := ../../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
@@ -37,6 +43,7 @@ EXE_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lfiniteVolume \
     -ldynamicFvMesh \
     -lmeshTools \

--- a/applications/solvers/mixing/mixingTransportFoam/Make/options
+++ b/applications/solvers/mixing/mixingTransportFoam/Make/options
@@ -8,6 +8,14 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+QBMM_SRC := ../../../../src
+
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/fvOptions/lnInclude \
@@ -18,14 +26,14 @@ EXE_INC = \
     -I$(LIB_SRC)/thermophysicalModels/radiation/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
-    -I$../../../../../src/quadratureMethods/univariateMomentSet/lnInclude \
-    -I$../../../../../src/quadratureMethods/momentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureNode/lnInclude \
-    -I$../../../../../src/quadratureMethods/moments \
-    -I$../../../../../src/quadratureMethods/fieldMomentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureApproximations/lnInclude \
-    -I$../../../../../src/quadratureMethods/momentAdvection/lnInclude \
-    -I$../../../../../src/quadratureMethods/mixingModels/lnInclude
+    -I$(QBMM_SRC)/quadratureMethods/univariateMomentSet/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/momentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureNode/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/moments \
+    -I$(QBMM_SRC)/quadratureMethods/fieldMomentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureApproximations/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/momentAdvection/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/mixingModels/lnInclude
 
 EXE_LIBS = \
     -lfiniteVolume \
@@ -38,6 +46,7 @@ EXE_LIBS = \
     -lradiationModels \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -L$(FOAM_MODULE_LIBBIN) \
     -lquadratureNode \
     -lmomentSets \

--- a/applications/solvers/multiphase/denseAGFoam/Make/options
+++ b/applications/solvers/multiphase/denseAGFoam/Make/options
@@ -10,6 +10,12 @@ endif
 
 QBMM_SRC := ../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
@@ -40,6 +46,7 @@ EXE_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lincompressibleTransportModels \
     -lfiniteVolume \
     -lfvOptions \

--- a/applications/solvers/multiphase/interfacialModels/Make/options
+++ b/applications/solvers/multiphase/interfacialModels/Make/options
@@ -5,6 +5,12 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
@@ -26,5 +32,6 @@ LIB_LIBS = \
     -lturbulenceModels \
     -lincompressibleTurbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -L$(FOAM_MODULE_LIBBIN) \
     -lpdPhaseSystem

--- a/applications/solvers/multiphase/phaseCompressibleTurbulenceModels/Make/options
+++ b/applications/solvers/multiphase/phaseCompressibleTurbulenceModels/Make/options
@@ -7,6 +7,12 @@ endif
 
 QBMM_SRC := ../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I../twoPhaseSystem/lnInclude \
     -I../interfacialModels/lnInclude \
@@ -37,6 +43,7 @@ LIB_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lincompressibleTransportModels \
     -lfvOptions \
     -lfiniteVolume \

--- a/applications/solvers/multiphase/polydisperseBubbleFoam/Make/options
+++ b/applications/solvers/multiphase/polydisperseBubbleFoam/Make/options
@@ -10,6 +10,12 @@ endif
 
 QBMM_SRC := ../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
@@ -40,6 +46,7 @@ EXE_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lincompressibleTransportModels \
     -lfiniteVolume \
     -lmeshTools \

--- a/applications/solvers/populationBalance/buoyantPbePimpleFoam/Make/options
+++ b/applications/solvers/populationBalance/buoyantPbePimpleFoam/Make/options
@@ -8,6 +8,14 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+QBMM_SRC := ../../../../src
+
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
@@ -17,14 +25,14 @@ EXE_INC = \
     -I$(LIB_SRC)/thermophysicalModels/radiation/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
-    -I$../../../../../src/quadratureMethods/univariateMomentSet/lnInclude \
-    -I$../../../../../src/quadratureMethods/momentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureNode/lnInclude \
-    -I$../../../../../src/quadratureMethods/moments \
-    -I$../../../../../src/quadratureMethods/fieldMomentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureApproximations/lnInclude \
-    -I$../../../../../src/quadratureMethods/momentAdvection/lnInclude \
-    -I$../../../../../src/quadratureMethods/populationBalanceModels/lnInclude
+    -I$(QBMM_SRC)/quadratureMethods/univariateMomentSet/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/momentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureNode/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/moments \
+    -I$(QBMM_SRC)/quadratureMethods/fieldMomentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureApproximations/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/momentAdvection/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/populationBalanceModels/lnInclude
 
 EXE_LIBS = \
     -lfiniteVolume \
@@ -37,6 +45,7 @@ EXE_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -latmosphericModels \
     -L$(FOAM_MODULE_LIBBIN) \
     -lquadratureNode \

--- a/applications/solvers/populationBalance/pbeFoam/Make/options
+++ b/applications/solvers/populationBalance/pbeFoam/Make/options
@@ -8,6 +8,14 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+QBMM_SRC := ../../../../src
+
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
@@ -18,19 +26,20 @@ EXE_INC = \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$../../../../../src/quadratureMethods/univariateMomentSet/lnInclude \
-    -I$../../../../../src/quadratureMethods/momentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureNode/lnInclude \
-    -I$../../../../../src/quadratureMethods/moments \
-    -I$../../../../../src/quadratureMethods/fieldMomentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureApproximations/lnInclude \
-    -I$../../../../../src/quadratureMethods/populationBalanceModels/lnInclude
+    -I$(QBMM_SRC)/quadratureMethods/univariateMomentSet/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/momentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureNode/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/moments \
+    -I$(QBMM_SRC)/quadratureMethods/fieldMomentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureApproximations/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/populationBalanceModels/lnInclude
 
 EXE_LIBS = \
     -lfiniteVolume \
     -lmeshTools \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lreactionThermophysicalModels \
     -lcompressibleTransportModels \
     -lfluidThermophysicalModels \

--- a/applications/solvers/populationBalance/pbeTransportFoam/Make/options
+++ b/applications/solvers/populationBalance/pbeTransportFoam/Make/options
@@ -8,6 +8,14 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+QBMM_SRC := ../../../../src
+
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/fvOptions/lnInclude \
@@ -18,14 +26,14 @@ EXE_INC = \
     -I$(LIB_SRC)/thermophysicalModels/radiation/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
-    -I$../../../../../src/quadratureMethods/univariateMomentSet/lnInclude \
-    -I$../../../../../src/quadratureMethods/momentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureNode/lnInclude \
-    -I$../../../../../src/quadratureMethods/moments \
-    -I$../../../../../src/quadratureMethods/fieldMomentInversion/lnInclude \
-    -I$../../../../../src/quadratureMethods/quadratureApproximations/lnInclude \
-    -I$../../../../../src/quadratureMethods/momentAdvection/lnInclude \
-    -I$../../../../../src/quadratureMethods/populationBalanceModels/lnInclude
+    -I$(QBMM_SRC)/quadratureMethods/univariateMomentSet/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/momentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureNode/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/moments \
+    -I$(QBMM_SRC)/quadratureMethods/fieldMomentInversion/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/quadratureApproximations/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/momentAdvection/lnInclude \
+    -I$(QBMM_SRC)/quadratureMethods/populationBalanceModels/lnInclude
 
 EXE_LIBS = \
     -lfiniteVolume \
@@ -38,6 +46,7 @@ EXE_LIBS = \
     -lradiationModels \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -L$(FOAM_MODULE_LIBBIN) \
     -lquadratureNode \
     -lmomentSets \

--- a/applications/solvers/velocityDistributionTransport/diluteVdfTransportFoam/Make/options
+++ b/applications/solvers/velocityDistributionTransport/diluteVdfTransportFoam/Make/options
@@ -10,6 +10,12 @@ endif
 
 QBMM_SRC := ../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/OpenFOAM/lnInclude \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
@@ -42,6 +48,7 @@ EXE_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lincompressibleTransportModels \
     -lfiniteVolume \
     -lfvOptions \

--- a/applications/solvers/velocityDistributionTransport/oneWayCoupledVdfTransportFoam/Make/options
+++ b/applications/solvers/velocityDistributionTransport/oneWayCoupledVdfTransportFoam/Make/options
@@ -10,6 +10,12 @@ endif
 
 QBMM_SRC := ../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
@@ -39,6 +45,7 @@ EXE_LIBS = \
     -lspecie \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lincompressibleTransportModels \
     -lfiniteVolume \
     -lfvOptions \

--- a/applications/solvers/velocityDistributionTransport/phaseCompressibleTurbulenceModels/Make/options
+++ b/applications/solvers/velocityDistributionTransport/phaseCompressibleTurbulenceModels/Make/options
@@ -7,6 +7,12 @@ endif
 
 QBMM_SRC := ../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
@@ -38,6 +44,7 @@ LIB_LIBS = \
     -lfluidThermophysicalModels \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lspecie \
     -lfvOptions \
     -L$(FOAM_MODULE_LIBBIN) \

--- a/applications/solvers/velocityDistributionTransport/phaseModel/Make/options
+++ b/applications/solvers/velocityDistributionTransport/phaseModel/Make/options
@@ -10,6 +10,12 @@ endif
 
 QBMM_SRC := ../../../../src
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
@@ -40,6 +46,7 @@ LIB_LIBS = \
     -lmeshTools \
     -lturbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lincompressibleTransportModels \
     -lcompressibleTransportModels \
     -lfluidThermophysicalModels \

--- a/src/quadratureMethods/mixingModels/Make/options
+++ b/src/quadratureMethods/mixingModels/Make/options
@@ -5,6 +5,12 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
@@ -34,6 +40,7 @@ LIB_LIBS = \
     -lturbulenceModels \
     -lincompressibleTurbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lfiniteVolume \
     -lmeshTools \
     -L$(FOAM_MODULE_LIBBIN) \

--- a/src/quadratureMethods/populationBalanceModels/Make/options
+++ b/src/quadratureMethods/populationBalanceModels/Make/options
@@ -5,6 +5,12 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
@@ -37,6 +43,7 @@ LIB_LIBS = \
     -lturbulenceModels \
     -lincompressibleTurbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lfiniteVolume \
     -lmeshTools \
     -L$(FOAM_MODULE_LIBBIN) \

--- a/src/quadratureMethods/quadratureApproximations/Make/options
+++ b/src/quadratureMethods/quadratureApproximations/Make/options
@@ -5,6 +5,12 @@ ifeq (,$(strip $(FOAM_MODULE_LIBBIN)))
     FOAM_MODULE_LIBBIN = $(FOAM_USER_LIBBIN)
 endif
 
+#if (OPENFOAM >= 2206)
+LIB_THERMO_TOOLS := -lthermoTools
+#else
+LIB_THERMO_TOOLS :=
+#endif
+
 EXE_INC = \
     -I$(LIB_SRC)/transportModels \
     -I$(LIB_SRC)/transportModels/compressible/lnInclude \
@@ -32,6 +38,7 @@ LIB_LIBS = \
     -lturbulenceModels \
     -lincompressibleTurbulenceModels \
     -lcompressibleTurbulenceModels \
+    $(LIB_THERMO_TOOLS) \
     -lfiniteVolume \
     -lmeshTools \
     -L$(FOAM_MODULE_LIBBIN) \


### PR DESCRIPTION
- handled conditionally so that Make/options should continue to work
  properly for older OpenFOAM versions as well.
  However, this treatment will precluded

COMP: consistent use of QBMM_SRC location macro

STYLE: catch erroneous -prefix=false compilations