### PR TITLE
COMP: use new setter method for face-flux pointers

### DIFF
--- a/applications/solvers/multiphase/denseAGFoam/pU/p_rghEqn.H
+++ b/applications/solvers/multiphase/denseAGFoam/pU/p_rghEqn.H
@@ -263,7 +263,13 @@ while (pimple.correct())
                   + fvm::div(phid1, p_rgh) - fvm::Sp(fvc::div(phid1), p_rgh)
                 )
             );
+
+        // For OpenFOAM-v2312 and earlier was raw pointer instead of unique_ptr
+        #if (OPENFOAM > 2312)
+        pEqnComp1.ref().faceFluxCorrectionPtr(nullptr);
+        #else
         deleteDemandDrivenData(pEqnComp1.ref().faceFluxCorrectionPtr());
+        #endif
         pEqnComp1.ref().relax();
 
         pEqnComp2 =
@@ -279,7 +285,13 @@ while (pimple.correct())
                   + fvm::div(phid2, p_rgh) - fvm::Sp(fvc::div(phid2), p_rgh)
                 )
             );
+
+        // For OpenFOAM-v2312 and earlier was raw pointer instead of unique_ptr
+        #if (OPENFOAM > 2312)
+        pEqnComp2.ref().faceFluxCorrectionPtr(nullptr);
+        #else
         deleteDemandDrivenData(pEqnComp2.ref().faceFluxCorrectionPtr());
+        #endif
         pEqnComp2.ref().relax();
     }
     else

--- a/applications/solvers/multiphase/polydisperseBubbleFoam/pU/pEqn.H
+++ b/applications/solvers/multiphase/polydisperseBubbleFoam/pU/pEqn.H
@@ -289,7 +289,13 @@ while (pimple.correct())
                   + fvm::div(phid1, p_rgh) - fvm::Sp(fvc::div(phid1), p_rgh)
                 )
             );
+
+        // For OpenFOAM-v2312 and earlier was raw pointer instead of unique_ptr
+        #if (OPENFOAM > 2312)
+        pEqnComp1.ref().faceFluxCorrectionPtr(nullptr);
+        #else
         deleteDemandDrivenData(pEqnComp1.ref().faceFluxCorrectionPtr());
+        #endif
         pEqnComp1.ref().relax();
 
         pEqnComp2 =
@@ -305,7 +311,13 @@ while (pimple.correct())
                   + fvm::div(phid2, p_rgh) - fvm::Sp(fvc::div(phid2), p_rgh)
                 )
             );
+
+        // For OpenFOAM-v2312 and earlier was raw pointer instead of unique_ptr
+        #if (OPENFOAM > 2312)
+        pEqnComp2.ref().faceFluxCorrectionPtr(nullptr);
+        #else
         deleteDemandDrivenData(pEqnComp2.ref().faceFluxCorrectionPtr());
+        #endif
         pEqnComp2.ref().relax();
     }
     else


### PR DESCRIPTION
Due to the following change: https://develop.openfoam.com/Development/openfoam/-/commit/cd8bc891f0ea0651fada48f19ffa51765d0299a1