### PR TITLE
COMP: replace ternary with direct assignment of local fields

### DIFF
--- a/applications/utilities/generateMoments/momentGenerationModels/alphaAndDiameter/alphaAndDiameter.C
+++ b/applications/utilities/generateMoments/momentGenerationModels/alphaAndDiameter/alphaAndDiameter.C
@@ -148,20 +148,21 @@ void Foam::momentGenerationSubModels::alphaAndDiameter::updateMoments
     }
 
     sumAlpha_ = max(sumAlpha_, SMALL);
-    
-    scalarField alpha
-    (
-        patchi == -1
-      ? alpha_.primitiveField()
-      : alpha_.boundaryField()[patchi]
-    );
-    
-    scalarField rho
-    (
-        patchi == -1
-      ? rho_.primitiveField()
-      : rho_.boundaryField()[patchi]
-    );
+
+    // Local alpha and rho fields.
+    // Copy from internal field or boundary field
+
+    scalarField alpha, rho;
+    if (patchi == -1)
+    {
+        alpha = alpha_.primitiveField();
+        rho = rho_.primitiveField();
+    }
+    else
+    {
+        alpha = alpha_.boundaryField()[patchi];
+        rho = rho_.boundaryField()[patchi];
+    }
 
     forAll(weights_, nodei)
     {


### PR DESCRIPTION
- https://develop.openfoam.com/Development/openfoam/-/merge_requests/757

  The return type of DimensionedField changed from Field<T> to DynamicField<T> as part of the effort to allow a combined internal+boundary field representation.

  As a consequence, there are a few places where a `static_cast<>` to Field may be needed.

  Also, using a ternary to select between internal and boundary fields will no longer compile. Either rewrite with a static_cast or simply don't use a ternary for this.